### PR TITLE
[ADD] 新增if条件下and\or\not\in\not in的逻辑

### DIFF
--- a/examples/readme_validation/README.md
+++ b/examples/readme_validation/README.md
@@ -26,6 +26,8 @@ examples/readme_validation/
 ├── auth.resource           # 认证相关关键字资源文件
 ├── data_driven.dsl         # 数据驱动测试示例（需要pytest运行）
 ├── data_driven.csv         # 数据驱动测试数据文件
+├── test_in_operator.dsl    # in和not in运算符测试示例
+├── test_logical_operators.dsl   # 逻辑运算符（and、or、not）测试示例
 └── test_runner.py          # pytest集成示例
 ```
 
@@ -92,6 +94,8 @@ pytest test_runner.py -v
 - **auth.resource**: 认证相关关键字资源文件
 - **data_driven.dsl**: 数据驱动测试示例（需要pytest运行）
 - **data_driven.csv**: 数据驱动测试数据文件
+- **test_in_operator.dsl**: 演示in和not in运算符的使用，包括列表、字符串、字典等场景
+- **test_logical_operators.dsl**: 演示逻辑运算符（and、or、not）的使用，包括复杂逻辑组合和优先级测试
 
 ### pytest集成示例
 

--- a/examples/readme_validation/run_all_tests.py
+++ b/examples/readme_validation/run_all_tests.py
@@ -67,6 +67,8 @@ def main():
         "auth_test.dsl",
         "test_dict_support.dsl",
         "test_if_elif_else.dsl",
+        "test_in_operator.dsl",  # 新增：in和not in运算符测试
+        "test_logical_operators.dsl",  # 新增：逻辑运算符（and、or、not）测试
         "test_break_continue_final.dsl",
         "boolean_demo.dsl",
         "../test_new_for_loops.dsl",  # 新增：for循环语法测试

--- a/examples/readme_validation/test_in_operator.dsl
+++ b/examples/readme_validation/test_in_operator.dsl
@@ -1,0 +1,71 @@
+@name: "in运算符测试"
+@description: "测试if语句中的in和not in运算符"
+@tags: ["in运算符", "测试"]
+
+# 测试1: 列表中的in运算符
+[打印], 内容: "=== 测试1: 列表中的in运算符 ==="
+items = ["apple", "banana", "orange"]
+item = "apple"
+
+if ${item} in ${items} do
+    [打印], 内容: "✓ ${item} 在列表中"
+else
+    [打印], 内容: "✗ ${item} 不在列表中"
+end
+
+# 测试2: 列表中的not in运算符
+[打印], 内容: "=== 测试2: 列表中的not in运算符 ==="
+item2 = "grape"
+
+if ${item2} not in ${items} do
+    [打印], 内容: "✓ ${item2} 不在列表中"
+else
+    [打印], 内容: "✗ ${item2} 在列表中"
+end
+
+# 测试3: 字符串中的in运算符
+[打印], 内容: "=== 测试3: 字符串中的in运算符 ==="
+text = "Hello, World!"
+substring = "World"
+
+if ${substring} in ${text} do
+    [打印], 内容: "✓ '${substring}' 在字符串中"
+else
+    [打印], 内容: "✗ '${substring}' 不在字符串中"
+end
+
+# 测试4: 字典键中的in运算符
+[打印], 内容: "=== 测试4: 字典键中的in运算符 ==="
+user = {"name": "张三", "age": 25, "city": "北京"}
+key = "name"
+
+if ${key} in ${user} do
+    [打印], 内容: "✓ '${key}' 是字典的键"
+else
+    [打印], 内容: "✗ '${key}' 不是字典的键"
+end
+
+# 测试5: in与其他运算符组合
+[打印], 内容: "=== 测试5: in与其他运算符组合 ==="
+numbers = [1, 2, 3, 4, 5]
+num = 3
+
+if ${num} in ${numbers} and ${num} > 2 do
+    [打印], 内容: "✓ ${num} 在列表中且大于2"
+else
+    [打印], 内容: "✗ 条件不满足"
+end
+
+# 测试6: not in与其他运算符组合
+[打印], 内容: "=== 测试6: not in与其他运算符组合 ==="
+status = "active"
+valid_statuses = ["active", "pending"]
+
+if ${status} not in ${valid_statuses} or ${status} == "inactive" do
+    [打印], 内容: "✓ 状态不在有效列表中或是inactive"
+else
+    [打印], 内容: "✗ 状态在有效列表中且不是inactive"
+end
+
+[打印], 内容: "=== in运算符测试完成 ==="
+

--- a/examples/readme_validation/test_logical_operators.dsl
+++ b/examples/readme_validation/test_logical_operators.dsl
@@ -1,0 +1,83 @@
+@name: "逻辑运算符测试"
+@description: "测试if语句中的and、or、not逻辑运算符"
+@tags: ["逻辑运算符", "测试"]
+
+# 测试1: and运算符
+[打印], 内容: "=== 测试1: and运算符 ==="
+user_role = "admin"
+user_active = True
+
+if user_role == "admin" and ${user_active} do
+    [打印], 内容: "✓ 管理员用户且状态活跃"
+else
+    [打印], 内容: "✗ 条件不满足"
+end
+
+# 测试2: 多个and组合
+[打印], 内容: "=== 测试2: 多个and组合 ==="
+age = 25
+country = "China"
+
+if ${age} >= 18 and country == "China" do
+    [打印], 内容: "✓ 符合条件的中国成年用户"
+else
+    [打印], 内容: "✗ 条件不满足"
+end
+
+# 测试3: or运算符
+[打印], 内容: "=== 测试3: or运算符 ==="
+user_type = "premium"
+
+if user_type == "premium" or user_type == "vip" do
+    [打印], 内容: "✓ 高级用户，享受特殊权限"
+else
+    [打印], 内容: "✗ 不是高级用户"
+end
+
+# 测试4: not运算符
+[打印], 内容: "=== 测试4: not运算符 ==="
+is_banned = False
+
+if not ${is_banned} do
+    [打印], 内容: "✓ 用户未被封禁，可以正常使用"
+else
+    [打印], 内容: "✗ 用户被封禁"
+end
+
+# 测试5: 复杂逻辑组合
+[打印], 内容: "=== 测试5: 复杂逻辑组合 ==="
+score = 85
+is_vip = True
+
+if ${score} >= 80 and ${is_vip} do
+    [打印], 内容: "✓ 高分VIP用户"
+elif ${score} >= 80 or ${is_vip} do
+    [打印], 内容: "✓ 高分或VIP用户"
+else
+    [打印], 内容: "✗ 普通用户"
+end
+
+# 测试6: not与其他运算符组合
+[打印], 内容: "=== 测试6: not与其他运算符组合 ==="
+status = "inactive"
+
+if not status == "active" do
+    [打印], 内容: "✓ 状态不是active"
+else
+    [打印], 内容: "✗ 状态是active"
+end
+
+# 测试7: 括号优先级测试
+[打印], 内容: "=== 测试7: 括号优先级测试 ==="
+x = 5
+y = 10
+z = 15
+
+if (${x} > 3 and ${y} < 20) or ${z} > 20 do
+    [打印], 内容: "✓ 括号优先级正确"
+else
+    [打印], 内容: "✗ 括号优先级错误"
+end
+
+[打印], 内容: "=== 逻辑运算符测试完成 ==="
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-dsl"
-version = "0.17.3"
+version = "0.17.4"
 description = "A DSL testing framework based on pytest"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pytest_dsl/__init__.py
+++ b/pytest_dsl/__init__.py
@@ -12,7 +12,7 @@ pytest-dsl - 基于pytest的DSL测试框架
 - 自定义关键字支持
 """
 
-__version__ = "0.17.3"
+__version__ = "0.17.4"
 
 # 核心执行器
 from pytest_dsl.core.dsl_executor import DSLExecutor

--- a/pytest_dsl/core/lexer.py
+++ b/pytest_dsl/core/lexer.py
@@ -18,7 +18,10 @@ reserved = {
     'function': 'FUNCTION',  # 添加function关键字支持，用于自定义关键字定义
     'teardown': 'TEARDOWN',   # 添加teardown关键字支持，用于清理操作
     'break': 'BREAK',  # 添加break关键字支持，用于循环控制
-    'continue': 'CONTINUE'  # 添加continue关键字支持，用于循环控制
+    'continue': 'CONTINUE',  # 添加continue关键字支持，用于循环控制
+    'and': 'AND',  # 添加逻辑与运算符
+    'or': 'OR',    # 添加逻辑或运算符
+    'not': 'NOT'   # 添加逻辑非运算符
 }
 
 # token 名称列表

--- a/pytest_dsl/remote/__init__.py
+++ b/pytest_dsl/remote/__init__.py
@@ -4,7 +4,7 @@ Remote module for pytest-dsl.
 This module provides remote keyword server functionality.
 """
 
-__version__ = "0.17.3"
+__version__ = "0.17.4"
 
 # 导出远程关键字管理器和相关功能
 from .keyword_client import remote_keyword_manager, RemoteKeywordManager, RemoteKeywordClient

--- a/uv.lock
+++ b/uv.lock
@@ -432,7 +432,7 @@ wheels = [
 
 [[package]]
 name = "pytest-dsl"
-version = "0.17.3"
+version = "0.17.4"
 source = { editable = "." }
 dependencies = [
     { name = "allure-pytest" },


### PR DESCRIPTION
[ADD] 新增if条件下and\or\not\in\not in的逻辑
orbitest通过截图：
<img width="1118" height="692" alt="Snipaste_2025-11-26_10-00-08" src="https://github.com/user-attachments/assets/e98f0a4b-48dd-4474-ac60-8f8ade312819" />
<img width="1067" height="614" alt="Snipaste_2025-11-26_10-06-51" src="https://github.com/user-attachments/assets/c9711131-ce7e-4855-a14b-961b3633ed4e" />

本地通过截图：
<img width="758" height="448" alt="1764042383137" src="https://github.com/user-attachments/assets/865122fc-8f1a-4f5f-bbf1-e8e9b6322bbd" />
<img width="892" height="455" alt="Snipaste_2025-11-26_10-15-00" src="https://github.com/user-attachments/assets/098a62ae-9222-4462-b27d-71c7cdea34aa" />

所有readme示例验证通过：
<img width="483" height="292" alt="image" src="https://github.com/user-attachments/assets/23db69b0-2557-4afb-8698-2c3defff3758" />